### PR TITLE
[init.qcom.rc] Patch hvdcp, charger_monitor to bind to netlink 0xFFFFFFFD

### DIFF
--- a/rootdir/root/init.qcom.rc
+++ b/rootdir/root/init.qcom.rc
@@ -893,6 +893,8 @@ service charger /charger
     class charger
 
 service hvdcp /system/bin/hvdcp
+    setenv UEVENT_NETLINK_GROUPS 0xFFFFFFFD
+    setenv LD_PRELOAD /usr/libexec/droid-hybris/system/lib/libcutils.so
     class core
     user root
     disabled
@@ -904,6 +906,8 @@ on property:persist.usb.hvdcp.detect=false
     stop hvdcp
 
 service charger_monitor /system/bin/charger_monitor
+    setenv UEVENT_NETLINK_GROUPS 0xFFFFFFFD
+    setenv LD_PRELOAD /usr/libexec/droid-hybris/system/lib/libcutils.so
     user system
     group system
     disabled


### PR DESCRIPTION
Because when binding to 0xFFFFFFFF, these blobs try to processes
messages from systemd-udevd to group 00000002